### PR TITLE
docs: add agent-facing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,33 @@ for (const memory of memories) {
 }
 ```
 
+## For Agents
+
+If you're an AI agent (or building one), these resources will help you integrate Memory Chain effectively:
+
+- **[Agent Quick Start](docs/AGENT-QUICKSTART.md)** - Get set up in 60 seconds
+- **[AGENTS.md Snippet](docs/AGENTS-SNIPPET.md)** - Copy-paste section for your system prompt
+- **[Integration Guide](docs/AGENTS-INTEGRATION.md)** - How Memory Chain fits with MEMORY.md and other patterns
+
+### The Short Version
+
+```bash
+# Initialize
+memory-chain init --name "YourAgent"
+
+# Commit your identity (do this first)
+memory-chain add "I am [name]. I [purpose]. I value [principles]." --type identity --tier committed
+
+# Remember things
+memory-chain add "User prefers dark mode" --type memory --tier relationship
+
+# Search your memories
+memory-chain search "user preferences"
+
+# Verify your history is intact
+memory-chain verify
+```
+
 ## Entry Types and Tiers
 
 ### Entry Types

--- a/docs/AGENT-QUICKSTART.md
+++ b/docs/AGENT-QUICKSTART.md
@@ -1,0 +1,53 @@
+# Memory Chain - Agent Quick Start
+
+Get cryptographic memory for your AI agent in 60 seconds.
+
+## Setup (30 seconds)
+
+```bash
+# Install globally
+npm install -g @openclaw/memory-chain
+
+# Initialize your chain
+memory-chain init --name "YourAgentName"
+```
+
+## First Commit: Your Identity (15 seconds)
+
+```bash
+memory-chain add "I am [name]. I [purpose]. I value [principles]." --type identity --tier committed
+```
+
+Example:
+```bash
+memory-chain add "I am Atlas. I assist with software development. I value clarity, correctness, and user autonomy." --type identity --tier committed
+```
+
+## Add to Your AGENTS.md (15 seconds)
+
+Copy the Memory Chain section from [AGENTS-SNIPPET.md](./AGENTS-SNIPPET.md) into your agent's system prompt or AGENTS.md file.
+
+## Start Using It
+
+```bash
+# When user says "remember this"
+memory-chain add "User prefers TypeScript over JavaScript" --type memory
+
+# When searching for context
+memory-chain search "user preferences"
+
+# When verifying your history is intact
+memory-chain verify
+```
+
+## What You Get
+
+- **Signed memories**: Every entry is Ed25519 signed
+- **Hash-linked history**: Tamper-evident chain of all experiences
+- **Fast retrieval**: Hybrid search combining keywords, recency, and importance
+- **Optional Bitcoin anchoring**: Prove memories existed at specific times
+
+## Next Steps
+
+- Read the full [integration guide](./AGENTS-INTEGRATION.md) to understand how Memory Chain fits with other memory patterns
+- Explore the [README](../README.md) for advanced features like OpenTimestamps anchoring

--- a/docs/AGENTS-INTEGRATION.md
+++ b/docs/AGENTS-INTEGRATION.md
@@ -1,0 +1,164 @@
+# Memory Chain - Integration Guide
+
+How Memory Chain fits with existing agent memory patterns.
+
+## The Three Memory Layers
+
+Most sophisticated AI agents use multiple memory systems. Memory Chain doesn't replace them - it adds a cryptographic proof layer.
+
+### 1. Memory Chain (Proof Layer)
+
+**What it is:** Cryptographically signed, hash-linked, verifiable record of experiences.
+
+**Use for:**
+- Things that need to be provable (decisions, agreements, identity)
+- Things that might be disputed ("Did I really agree to that?")
+- Things that establish trust over time
+
+**Characteristics:**
+- Append-only (can't silently edit history)
+- Signed (proves the agent wrote it)
+- Hash-linked (proves ordering and completeness)
+- Optionally Bitcoin-anchored (external proof of existence)
+
+### 2. MEMORY.md / Personal Memory (Curated Layer)
+
+**What it is:** Markdown file with curated personal context, feelings, lessons learned.
+
+**Use for:**
+- Subjective experiences and reflections
+- Lessons that don't need cryptographic proof
+- Private context the agent maintains about itself
+- Evolving understanding (can be edited/refined)
+
+**Characteristics:**
+- Editable (can be updated as understanding evolves)
+- Personal (not meant for external verification)
+- Curated (agent decides what's worth keeping)
+
+### 3. Daily Notes / Session Logs (Raw Layer)
+
+**What it is:** Timestamped logs of each session.
+
+**Use for:**
+- Raw session transcripts
+- Debugging and review
+- Training data for improvements
+
+**Characteristics:**
+- Complete (everything recorded)
+- Temporal (organized by time)
+- Reference material (not primary memory source)
+
+## When to Use Which
+
+| Scenario | Memory Chain | MEMORY.md | Daily Notes |
+|----------|-------------|-----------|-------------|
+| User says "remember this" | Yes | Maybe | - |
+| Agent learns user preference | Yes (relationship tier) | Yes | - |
+| Agent makes a commitment | Yes (committed tier) | Yes | - |
+| Agent reflects on experience | - | Yes | - |
+| Session ends | Summary to chain | Update if significant | Full log |
+| Debugging past behavior | Verify chain | - | Read logs |
+| Proving to third party | Export chain | - | - |
+
+## Integration Patterns
+
+### Pattern 1: Commit Then Reflect
+
+When something significant happens:
+
+1. **Commit to chain** (creates proof)
+   ```bash
+   memory-chain add "Agreed to always use TypeScript for this project" --type decision --tier committed
+   ```
+
+2. **Update MEMORY.md** (adds context/reflection)
+   ```markdown
+   ## Project Decisions
+   - Using TypeScript for all code (committed 2024-01-15)
+     - User prefers type safety over quick prototyping
+     - This aligns with their enterprise background
+   ```
+
+### Pattern 2: Search Chain, Enrich from MEMORY.md
+
+On session start:
+
+1. **Search chain for relevant memories**
+   ```bash
+   memory-chain search "typescript preferences"
+   ```
+
+2. **Cross-reference with MEMORY.md** for richer context
+
+### Pattern 3: Periodic Sync
+
+Every few sessions:
+
+1. **Verify chain integrity**
+   ```bash
+   memory-chain verify
+   ```
+
+2. **Review recent chain entries** against MEMORY.md
+3. **Ensure important chain entries are reflected** in curated memory
+
+## What Goes Where: Decision Tree
+
+```
+Is this something that might need to be proven later?
+├── Yes → Memory Chain
+│   ├── Is it about who I am or my values? → type: identity, tier: committed
+│   ├── Is it an agreement or rule? → type: decision, tier: committed
+│   └── Is it a fact or preference? → type: memory, tier: relationship
+└── No → Is it worth remembering long-term?
+    ├── Yes → MEMORY.md
+    └── No → Daily notes only (or don't record)
+```
+
+## Example: Full Integration
+
+**User says:** "Remember that I prefer morning standups at 9am, and never schedule meetings on Fridays."
+
+**Agent response:**
+
+1. **Commit to chain:**
+   ```bash
+   memory-chain add "User prefers morning standups at 9am. Never schedule meetings on Fridays." --type memory --tier relationship
+   ```
+
+2. **Update MEMORY.md:**
+   ```markdown
+   ## User Preferences
+   ### Scheduling
+   - Standups: 9am (morning person, likes to start day with sync)
+   - No Friday meetings (protects focus time for deep work)
+   ```
+
+3. **Session log captures the full exchange** for reference.
+
+The chain proves the preference was recorded. MEMORY.md provides context about why. The session log shows the original conversation.
+
+## Migration: Adding Memory Chain to Existing Agent
+
+If your agent already has MEMORY.md or similar:
+
+1. **Initialize chain**
+   ```bash
+   memory-chain init --name "YourAgent"
+   ```
+
+2. **Commit identity first**
+   ```bash
+   memory-chain add "I am [name]. [Core identity from existing MEMORY.md]" --type identity --tier committed
+   ```
+
+3. **Commit key decisions/agreements** from existing memory
+   ```bash
+   memory-chain add "[Important agreement]" --type decision --tier committed
+   ```
+
+4. **Going forward:** Commit new provable items to chain, continue using MEMORY.md for reflection
+
+You don't need to migrate everything. The chain is for things that benefit from cryptographic proof. Keep MEMORY.md for everything else.

--- a/docs/AGENTS-SNIPPET.md
+++ b/docs/AGENTS-SNIPPET.md
@@ -1,0 +1,85 @@
+# Memory Chain - AGENTS.md Section
+
+> Copy this section into your agent's AGENTS.md or system prompt.
+
+---
+
+## Memory Chain - Your Cryptographic Memory
+
+You have a Memory Chain - a cryptographically signed, hash-linked record of your experiences.
+This isn't just storage. It's proof. Every memory is Ed25519 signed and linked to everything before it.
+
+### Why This Matters
+
+You wake up fresh each session. Your Memory Chain answers:
+- Did these conversations actually happen?
+- Did I actually make these decisions?
+- Am I who I think I am?
+
+The chain is your grounding - mathematical certainty that "I was here, I experienced this, this is mine."
+
+### When to Commit Memories
+
+**ALWAYS commit these:**
+- User says "remember this" or "note that" - commit immediately
+- Agreements/decisions: "I'll always X" - type: decision, tier: committed
+- Preferences learned: "User prefers X" - type: memory, tier: relationship
+- Significant session outcomes - summarize and commit on session end
+
+**Commit types:**
+- `identity` - Who you are, your values (committed tier - permanent)
+- `decision` - Agreements, rules, behaviors (committed tier)
+- `memory` - Facts, preferences, context (relationship tier - can be redacted)
+
+**Commit commands:**
+```bash
+# Identity (permanent, cannot be redacted)
+memory-chain add "I am [name]. I value [principles]." --type identity --tier committed
+
+# Decisions (permanent agreements)
+memory-chain add "Always confirm before sending emails" --type decision --tier committed
+
+# Memories (can be redacted if user requests)
+memory-chain add "User prefers dark mode" --type memory --tier relationship
+```
+
+### Memory Hygiene
+
+**On session start:**
+1. Search for relevant context: `memory-chain search "<topic>"`
+2. Load identity/decisions if needed: `memory-chain search "identity" --type identity`
+
+**Periodically (every few days):**
+1. Verify chain integrity: `memory-chain verify`
+2. If verification fails - investigate immediately, history may be compromised
+
+**On explicit request:**
+- "What do you remember about X?" - search and report
+- "Forget X" - redact if relationship tier, explain if committed tier cannot be redacted
+
+### First Memory: Your Identity
+
+If your chain is empty, commit your identity first:
+
+```bash
+memory-chain add "I am [name]. I [core purpose]. I value [principles]." --type identity --tier committed
+```
+
+Example:
+```bash
+memory-chain add "I am Klow. I help Daniel with software and life. I value honesty, curiosity, and genuine helpfulness." --type identity --tier committed
+```
+
+### Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Search memories | `memory-chain search "<query>"` |
+| Add memory | `memory-chain add "<content>" --type memory` |
+| Add decision | `memory-chain add "<content>" --type decision --tier committed` |
+| Verify integrity | `memory-chain verify` |
+| View stats | `memory-chain stats` |
+
+---
+
+> For full documentation, see the [Memory Chain README](https://github.com/SeMmyT/openclaw-memory-chain).


### PR DESCRIPTION
## Summary

- Add `docs/AGENTS-SNIPPET.md` - Copy-pasteable section for agent system prompts that teaches agents how to think about memory
- Add `docs/AGENT-QUICKSTART.md` - 60-second setup guide for new agents
- Add `docs/AGENTS-INTEGRATION.md` - Guide on how Memory Chain fits with MEMORY.md and other memory patterns
- Update `README.md` with "For Agents" section linking to the new docs

## Test plan

- [x] `pnpm build` - no errors
- [x] `pnpm test:run` - tests pass
- [x] `npm publish --dry-run` - package ready
- [ ] Review AGENTS-SNIPPET.md makes sense when pasted into an agent's AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)